### PR TITLE
Choice restrictions

### DIFF
--- a/onyx/data/management/commands/choicerestrictions.py
+++ b/onyx/data/management/commands/choicerestrictions.py
@@ -1,0 +1,49 @@
+from django.core.management import base
+from django.contrib.contenttypes.models import ContentType
+from data.models import Choice
+import csv
+
+
+def _print(*args, quiet=False, **kwargs):
+    if not quiet:
+        print(*args, **kwargs)
+
+
+class Command(base.BaseCommand):
+    help = "Set choice restrictions in the database."
+
+    def add_arguments(self, parser):
+        parser.add_argument("scheme")
+        parser.add_argument("--quiet")
+
+    def handle(self, *args, **options):
+        with open(options["scheme"]) as scheme:
+            reader = csv.DictReader(scheme, skipinitialspace=True)
+
+            for row in reader:
+                app_label, model = row["content_type"].strip().split(".")
+                content_type = ContentType.objects.get(app_label=app_label, model=model)
+                field = row["field"].strip()
+                choice = row["choice"].strip()
+                restricted_to_field = row["restricted_to_field"].strip()
+                restricted_to_choices = [
+                    x.strip() for x in row["restricted_to_choices"].split(":")
+                ]
+                choice_instance = Choice.objects.get(
+                    content_type=content_type, field=field, choice=choice
+                )
+                restricted_instances = [
+                    Choice.objects.get(
+                        content_type=content_type,
+                        field=restricted_to_field,
+                        choice=restricted_to_choice,
+                    )
+                    for restricted_to_choice in restricted_to_choices
+                ]
+                for restricted_instance in restricted_instances:
+                    choice_instance.restricted_to.add(restricted_instance)
+                    restricted_instance.restricted_to.add(choice_instance)
+                    _print(
+                        f"Created restriction: {content_type.app_label} | {content_type.model_class()} | ({choice_instance.field}, {choice_instance.choice}) | ({restricted_instance.field}, {restricted_instance.choice})",
+                        quiet=options["quiet"],
+                    )

--- a/onyx/data/models/models.py
+++ b/onyx/data/models/models.py
@@ -65,6 +65,7 @@ class Choice(models.Model):
     field = models.TextField()
     choice = LowerCharField(max_length=100)
     is_active = models.BooleanField(default=True)
+    restricted_to = models.ManyToManyField("Choice", related_name="restricted_from")
 
     class Meta:
         indexes = [

--- a/onyx/data/serializers/serializers.py
+++ b/onyx/data/serializers/serializers.py
@@ -8,6 +8,7 @@ from utils.validation import (
     enforce_orderings,
     enforce_non_futures,
     enforce_identifiers,
+    enforce_choice_restrictions,
 )
 
 
@@ -248,6 +249,14 @@ class BaseRecordSerializer(serializers.ModelSerializer):
                 instance=self.instance,
             )
 
+            enforce_choice_restrictions(
+                errors=errors,
+                data=data,
+                choice_restrictions=self.OnyxMeta.choice_restrictions,
+                model=self.Meta.model,
+                instance=self.instance,
+            )
+
             enforce_non_futures(
                 errors=errors,
                 data=data,
@@ -274,6 +283,7 @@ class BaseRecordSerializer(serializers.ModelSerializer):
         optional_value_groups = []
         orderings = []
         non_futures = []
+        choice_restrictions = []
 
 
 class ProjectRecordSerializer(BaseRecordSerializer):


### PR DESCRIPTION
- Introduced choice restrictions as a `ManyToMany` field from `Choice` onto itself.
- Now a row in this table (such as a particular country on a country field) can be linked to multiple other rows (such as particular country regions on a country region field) for example.
- Object-level validation for this linkage has been added and is enforced at the serializer level.
- NOTE: It is NOT enforced at the database level, but I cannot see any easy way to do that.