### PR TITLE
Update to validation response codes 

### DIFF
--- a/onyx/accounts/permissions.py
+++ b/onyx/accounts/permissions.py
@@ -99,6 +99,7 @@ class IsSameSiteAsObject(permissions.BasePermission):
         )
 
 
+# TODO: Maybe split this up, and not require view group on everything
 class IsInProjectGroup(permissions.BasePermission):
     """
     Allows access only to users who are in the view group and the given action group for the given project.

--- a/onyx/accounts/permissions.py
+++ b/onyx/accounts/permissions.py
@@ -113,7 +113,7 @@ class IsInProjectGroup(permissions.BasePermission):
         # Check the user's permission to view the project
         # If the project isn't found, or the user doesn't have permission, tell them it doesn't exist
         if not request.user.groups.filter(name=view_group).exists():
-            raise exceptions.NotFound("Project not found.")
+            raise exceptions.NotFound({"detail": "Project not found."})
 
         # Check the user's permission to perform action on the project
         # If the user is missing permissions, tell them
@@ -143,7 +143,7 @@ class IsInScopeGroups(permissions.BasePermission):
             # Check the user's permission to view the scope
             # If the scope isn't found, or the user doesn't have permission, tell them it doesn't exist
             if not request.user.groups.filter(name=view_group).exists():
-                raise exceptions.NotFound("Scope not found.")
+                raise exceptions.NotFound({"detail": "Scope not found."})
 
             # Check the user's permission to perform action on the scope
             # If the user is missing permissions, tell them

--- a/onyx/accounts/serializers.py
+++ b/onyx/accounts/serializers.py
@@ -1,4 +1,4 @@
-from rest_framework import serializers
+from rest_framework import serializers, exceptions
 from .models import User
 from django.core.exceptions import ValidationError
 import django.contrib.auth.password_validation as validators
@@ -34,14 +34,14 @@ class CreateUserSerializer(serializers.ModelSerializer):
 
     def validate_first_name(self, value):
         if not value.isalpha():
-            raise serializers.ValidationError(
+            raise exceptions.ValidationError(
                 "This field must only contain alphabetic characters."
             )
         return value
 
     def validate_last_name(self, value):
         if not value.isalpha():
-            raise serializers.ValidationError(
+            raise exceptions.ValidationError(
                 "This field must only contain alphabetic characters."
             )
         return value
@@ -58,7 +58,7 @@ class CreateUserSerializer(serializers.ModelSerializer):
             errors["password"] = list(e.messages)
 
         if errors:
-            raise serializers.ValidationError(errors)
+            raise exceptions.ValidationError(errors)
 
         return data
 

--- a/onyx/accounts/views.py
+++ b/onyx/accounts/views.py
@@ -176,7 +176,7 @@ class AdminUserProjectsView(APIView):
 
         if not isinstance(request.data, list):
             raise exceptions.ValidationError(
-                {"detail": f"Expected a list but received type: {type(request.data)}"}
+                f"Expected a list but received type: {type(request.data)}"
             )
 
         existing_groups = user.groups.filter(name__startswith="view.project.")

--- a/onyx/accounts/views.py
+++ b/onyx/accounts/views.py
@@ -52,7 +52,7 @@ class SiteApproveView(APIView):
                     username=username
                 )
         except User.DoesNotExist:
-            raise exceptions.NotFound("User not found.")
+            raise exceptions.NotFound({"detail": "User not found."})
 
         # Approve user
         user.is_site_approved = True
@@ -79,7 +79,7 @@ class AdminApproveView(APIView):
         try:
             user = User.objects.get(username=username)
         except User.DoesNotExist:
-            raise exceptions.NotFound("User not found.")
+            raise exceptions.NotFound({"detail": "User not found."})
 
         # Approve user
         user.is_admin_approved = True
@@ -172,11 +172,11 @@ class AdminUserProjectsView(APIView):
         try:
             user = User.objects.get(username=username)
         except User.DoesNotExist:
-            raise exceptions.NotFound("User not found.")
+            raise exceptions.NotFound({"detail": "User not found."})
 
         if not isinstance(request.data, list):
             raise exceptions.ValidationError(
-                f"Expected a list but received type: {type(request.data)}"
+                {"detail": f"Expected a list but received type: {type(request.data)}"}
             )
 
         existing_groups = user.groups.filter(name__startswith="view.project.")
@@ -186,7 +186,7 @@ class AdminUserProjectsView(APIView):
             try:
                 group = Group.objects.get(name=f"view.project.{project}")
             except Group.DoesNotExist:
-                raise exceptions.NotFound("Project not found.")
+                raise exceptions.NotFound({"detail": "Project not found."})
             groups.append(group)
 
         removed = []

--- a/onyx/accounts/views.py
+++ b/onyx/accounts/views.py
@@ -14,7 +14,6 @@ from .serializers import (
     AdminWaitingSerializer,
 )
 from .permissions import Any, Approved, SiteAuthority, Admin
-from internal.exceptions import UnprocessableEntityError
 
 
 class LoginView(KnoxLoginView):
@@ -176,7 +175,7 @@ class AdminUserProjectsView(APIView):
             raise exceptions.NotFound("User not found.")
 
         if not isinstance(request.data, list):
-            raise UnprocessableEntityError(
+            raise exceptions.ValidationError(
                 {"detail": f"Expected a list but received type: {type(request.data)}"}
             )
 
@@ -208,3 +207,10 @@ class AdminUserProjectsView(APIView):
                 "removed": removed,
             },
         )
+
+
+class CreateProjectUserView(APIView):
+    permission_classes = Admin
+
+    def post(self, request, code, username):
+        pass

--- a/onyx/data/serializers/serializers.py
+++ b/onyx/data/serializers/serializers.py
@@ -14,6 +14,7 @@ from ..validators import (
 
 # TODO: Need to try out some nested FK data
 # TODO: Need to handle required FKs, not just optional many-to-one
+# TODO: Catch parse-errors within the keys that they occured?
 class SerializerNode:
     def __init__(self, serializer_class, data=None, context=None):
         self.serializer_class = serializer_class
@@ -26,7 +27,7 @@ class SerializerNode:
 
         if not isinstance(data, dict):
             raise exceptions.ValidationError(
-                "Expected a dictionary when parsing the request data."
+                {"detail": "Expected a dictionary when parsing the request data."}
             )
 
         related_data = {}
@@ -45,7 +46,7 @@ class SerializerNode:
 
                 if not isinstance(field_data, list):
                     raise exceptions.ValidationError(
-                        f"Expected a list when parsing the {field} data."
+                        {"detail": f"Expected a list when parsing the {field} data."}
                     )
 
                 for f_d in field_data:
@@ -59,7 +60,9 @@ class SerializerNode:
             else:
                 if not isinstance(field_data, dict):
                     raise exceptions.ValidationError(
-                        f"Expected a dictionary when parsing the {field} data."
+                        {
+                            "detail": f"Expected a dictionary when parsing the {field} data."
+                        }
                     )
 
                 self.nodes[field] = SerializerNode(
@@ -179,7 +182,9 @@ class SerializerNode:
             # Inform the user of any details regarding an IntegrityError
             # Otherwise, they will just see the generic 'Internal Server Error' message
             if isinstance(e.__cause__, IntegrityError):
-                raise exceptions.ValidationError(f"IntegrityError: {e.__cause__}")
+                raise exceptions.ValidationError(
+                    {"detail": f"IntegrityError: {e.__cause__}"}
+                )
             else:
                 raise e.__cause__  #  type: ignore
 

--- a/onyx/data/tests/views/test_create.py
+++ b/onyx/data/tests/views/test_create.py
@@ -195,7 +195,7 @@ class TestCreateView(OnyxTestCase):
         payload = copy.deepcopy(default_payload)
         payload["suppressed"] = "helloooo"
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -204,7 +204,7 @@ class TestCreateView(OnyxTestCase):
         payload["hello"] = "hi"
         payload["goodbye"] = "bye"
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -212,7 +212,7 @@ class TestCreateView(OnyxTestCase):
         payload = copy.deepcopy(default_payload)
         payload.pop("sample_id")
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -220,7 +220,7 @@ class TestCreateView(OnyxTestCase):
         payload = copy.deepcopy(default_payload)
         payload["records"][0].pop("test_id")
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -228,7 +228,7 @@ class TestCreateView(OnyxTestCase):
         payload = copy.deepcopy(default_payload)
         payload.pop("country")
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -236,7 +236,7 @@ class TestCreateView(OnyxTestCase):
         payload = copy.deepcopy(default_payload)
         payload["records"][0]["score_c"] = 42.3
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -277,7 +277,7 @@ class TestCreateView(OnyxTestCase):
 
         payload = copy.deepcopy(default_payload)
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 3
         assert (
             TestModel.objects.filter(sample_id=default_payload["sample_id"]).count()
@@ -301,7 +301,7 @@ class TestCreateView(OnyxTestCase):
         payload.pop("collection_month")
         payload.pop("received_month")
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -310,7 +310,7 @@ class TestCreateView(OnyxTestCase):
         payload["records"][0].pop("score_a", None)
         payload["records"][0].pop("score_b", None)
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -320,7 +320,7 @@ class TestCreateView(OnyxTestCase):
         payload["collection_month"] = "2023-02"
         payload["received_month"] = "2023-01"
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -331,7 +331,7 @@ class TestCreateView(OnyxTestCase):
         payload["end"] = start
         payload["start"] = end
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -340,7 +340,7 @@ class TestCreateView(OnyxTestCase):
         payload["records"][1]["test_start"] = "2023-04"
         payload["records"][1]["test_end"] = "2023-03"
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -348,7 +348,7 @@ class TestCreateView(OnyxTestCase):
         payload = copy.deepcopy(default_payload)
         payload["sample_id"] = "A" * 1000 + "H"
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -357,7 +357,7 @@ class TestCreateView(OnyxTestCase):
             payload = copy.deepcopy(default_payload)
             payload["collection_month"] = bad_yearmonth
             response = self.client.post(self.endpoint, data=payload)
-            self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             assert TestModel.objects.count() == 0
             assert TestModelRecord.objects.count() == 0
 
@@ -367,7 +367,7 @@ class TestCreateView(OnyxTestCase):
             "%Y-%m"
         )
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -376,7 +376,7 @@ class TestCreateView(OnyxTestCase):
             payload = copy.deepcopy(default_payload)
             payload["submission_date"] = bad_date
             response = self.client.post(self.endpoint, data=payload)
-            self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             assert TestModel.objects.count() == 0
             assert TestModelRecord.objects.count() == 0
 
@@ -386,7 +386,7 @@ class TestCreateView(OnyxTestCase):
             "%Y-%m-%d"
         )
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -407,7 +407,7 @@ class TestCreateView(OnyxTestCase):
             payload = copy.deepcopy(default_payload)
             payload["region"] = bad_choice
             response = self.client.post(self.endpoint, data=payload)
-            self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             assert TestModel.objects.count() == 0
             assert TestModelRecord.objects.count() == 0
 
@@ -415,14 +415,14 @@ class TestCreateView(OnyxTestCase):
         payload = copy.deepcopy(default_payload)
         payload["country"] = "wales"
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
         payload = copy.deepcopy(default_payload)
         payload["region"] = "other"
         response = self.client.post(self.endpoint, data=payload)
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
         assert TestModelRecord.objects.count() == 0
 
@@ -443,7 +443,7 @@ class TestCreateView(OnyxTestCase):
             payload = copy.deepcopy(default_payload)
             payload["concern"] = bad_bool
             response = self.client.post(self.endpoint, data=payload)
-            self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             assert TestModel.objects.count() == 0
             assert TestModelRecord.objects.count() == 0
 
@@ -464,7 +464,7 @@ class TestCreateView(OnyxTestCase):
             payload = copy.deepcopy(default_payload)
             payload["tests"] = bad_int
             response = self.client.post(self.endpoint, data=payload)
-            self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             assert TestModel.objects.count() == 0
             assert TestModelRecord.objects.count() == 0
 
@@ -485,14 +485,14 @@ class TestCreateView(OnyxTestCase):
             payload = copy.deepcopy(default_payload)
             payload["score"] = bad_float
             response = self.client.post(self.endpoint, data=payload)
-            self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             assert TestModel.objects.count() == 0
             assert TestModelRecord.objects.count() == 0
 
     def test_empty_request_fail(self):
         for payload in [None, {}]:
             response = self.client.post(self.endpoint, data=payload)
-            self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             assert TestModel.objects.count() == 0
             assert TestModelRecord.objects.count() == 0
 

--- a/onyx/data/tests/views/test_filter.py
+++ b/onyx/data/tests/views/test_filter.py
@@ -44,7 +44,7 @@ class TestFilterView(OnyxTestCase):
 
     def test_unknown_field_fail(self):
         response = self.client.get(self.endpoint, data={"hello": ":)"})
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_choicefield_ok(self):
         response = self.client.get(self.endpoint, data={"country": "eng"})
@@ -87,11 +87,11 @@ class TestFilterView(OnyxTestCase):
 
     def test_choicefield_wronglookup_fail(self):
         response = self.client.get(self.endpoint, data={"country__range": "eng,wales"})
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_choicefield_wrongchoice_fail(self):
         response = self.client.get(self.endpoint, data={"country": "ing"})
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_relation_isnull_ok(self):
         response = self.client.get(self.endpoint, data={"records__isnull": True})
@@ -110,7 +110,7 @@ class TestFilterView(OnyxTestCase):
 
     def test_relation_wronglookup_fail(self):
         response = self.client.get(self.endpoint, data={"records": 1})
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_charfield_ok(self):
         response = self.client.get(self.endpoint, data={"run_name": "run-1"})
@@ -165,7 +165,7 @@ class TestFilterView(OnyxTestCase):
 
     def test_charfield_badlookup_fail(self):
         response = self.client.get(self.endpoint, data={"run_name__year": "2022"})
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_number_ok(self):
         response = self.client.get(self.endpoint, data={"start": 5})

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -162,7 +162,7 @@ def filter_query(self, request, code):
             # e.g. If you pass a list, it assumes it is as a str, and tries to split by a comma
             atoms = make_atoms(query, to_str=True)  #  type: ignore
         except QueryException as e:
-            raise exceptions.ParseError(f"Error while parsing query: {e.args[0]}")
+            raise exceptions.ValidationError(e.args[0])
     else:
         atoms = []
 
@@ -213,7 +213,7 @@ def filter_query(self, request, code):
         try:
             q_object = make_query(query)  #  type: ignore
         except QueryException as e:
-            raise exceptions.ParseError(f"Error while parsing query: {e.args[0]}")
+            raise exceptions.ValidationError(e.args[0])
 
         # A queryset is not guaranteed to return unique objects
         # Especially as a result of complex nested queries

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -187,7 +187,7 @@ def filter_query(self, request, code):
     except FieldDoesNotExist as e:
         raise exceptions.ValidationError({"unknown_fields": e.args[0]})
     except ValidationError as e:
-        raise exceptions.ValidationError({"detail": e.args[0]})
+        raise exceptions.ValidationError(e.args[0])
 
     # View fields
     fields = view_fields(

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -113,7 +113,7 @@ class GetRecordView(ProjectAPIView):
                 .get(cid=cid)
             )
         except self.model.DoesNotExist:
-            raise exceptions.NotFound("CID not found.")
+            raise exceptions.NotFound({"detail": "CID not found."})
 
         # Serialize the result
         serializer = self.serializer_cls(
@@ -162,7 +162,7 @@ def filter_query(self, request, code):
             # e.g. If you pass a list, it assumes it is as a str, and tries to split by a comma
             atoms = make_atoms(query, to_str=True)  #  type: ignore
         except QueryException as e:
-            raise exceptions.ValidationError(e.args[0])
+            raise exceptions.ValidationError({"detail": e.args[0]})
     else:
         atoms = []
 
@@ -187,7 +187,7 @@ def filter_query(self, request, code):
     except FieldDoesNotExist as e:
         raise exceptions.ValidationError({"unknown_fields": e.args[0]})
     except ValidationError as e:
-        raise exceptions.ValidationError(e.args[0])
+        raise exceptions.ValidationError({"detail": e.args[0]})
 
     # View fields
     fields = view_fields(
@@ -213,7 +213,7 @@ def filter_query(self, request, code):
         try:
             q_object = make_query(query)  #  type: ignore
         except QueryException as e:
-            raise exceptions.ValidationError(e.args[0])
+            raise exceptions.ValidationError({"detail": e.args[0]})
 
         # A queryset is not guaranteed to return unique objects
         # Especially as a result of complex nested queries
@@ -292,7 +292,7 @@ class UpdateRecordView(ProjectAPIView):
                 .get(cid=cid)
             )
         except self.model.DoesNotExist:
-            raise exceptions.NotFound("CID not found.")
+            raise exceptions.NotFound({"detail": "CID not found."})
 
         # Validate the data
         node = SerializerNode(
@@ -329,7 +329,7 @@ class SuppressRecordView(ProjectAPIView):
                 .get(cid=cid)
             )
         except self.model.DoesNotExist:
-            raise exceptions.NotFound("CID not found.")
+            raise exceptions.NotFound({"detail": "CID not found."})
 
         # Suppress the instance
         if not test:
@@ -353,7 +353,7 @@ class DeleteRecordView(ProjectAPIView):
         try:
             instance = self.model.objects.select_related().get(cid=cid)
         except self.model.DoesNotExist:
-            raise exceptions.NotFound("CID not found.")
+            raise exceptions.NotFound({"detail": "CID not found."})
 
         # Delete the instance
         if not test:

--- a/onyx/internal/exceptions.py
+++ b/onyx/internal/exceptions.py
@@ -1,5 +1,0 @@
-from rest_framework import status, exceptions
-
-
-class UnprocessableEntityError(exceptions.ValidationError):
-    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/onyx/utils/fieldserializers.py
+++ b/onyx/utils/fieldserializers.py
@@ -1,6 +1,5 @@
 from datetime import date
-from rest_framework import serializers
-from rest_framework.validators import ValidationError
+from rest_framework import serializers, exceptions
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext_lazy as _
@@ -21,7 +20,7 @@ class YearMonthField(serializers.Field):
                 raise ValueError
             value = date(int(year), int(month), 1)
         except ValueError:
-            raise ValidationError("Enter a valid date in YYYY-MM format.")
+            raise exceptions.ValidationError("Enter a valid date in YYYY-MM format.")
 
         return value
 
@@ -29,7 +28,7 @@ class YearMonthField(serializers.Field):
         try:
             year, month, _ = str(value).split("-")
         except ValueError:
-            raise ValidationError("Must be in YYYY-MM-DD format.")
+            raise exceptions.ValidationError("Must be in YYYY-MM-DD format.")
 
         return year + "-" + month
 

--- a/onyx/utils/projectfields.py
+++ b/onyx/utils/projectfields.py
@@ -3,7 +3,6 @@ from django.contrib.auth.models import Group
 from rest_framework import exceptions
 from data.filters import ALL_LOOKUPS
 from .fields import ModelChoiceField
-from internal.exceptions import UnprocessableEntityError
 
 
 class OnyxField:
@@ -150,7 +149,7 @@ def resolve_fields(project, model, user, action, fields):
                 continue
 
     if unknown:
-        raise UnprocessableEntityError({"unknown_fields": unknown})
+        raise exceptions.ValidationError({"unknown_fields": unknown})
 
     if required:
         raise exceptions.PermissionDenied(


### PR DESCRIPTION
- Following realising some inconsistencies in error status codes (accounts views were returning 400 where the data views would return a 422 for the same thing), and because I was flying against DRF conventions, I have decided to move all validation errors (be it field or response structure related) under the 400 status code
- This is less specific, but provides an immediately understandable system: 400 is for an error in the users' request content, 401 is for authorisation failure, 403 is for permissions failure, and 500 is for an uncaught server error. 
